### PR TITLE
feat: make format and make format_check in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,17 @@ re: fclean all
 quick:
 	ghc app/*.hs src/*.hs -o $(NAME)
 
+format:
+	IFS=$$'\n' sourceFiles=("$$(find src test -type f -name "*.hs")"); \
+	ormolu -m inplace $${sourceFiles[*]}
+
+format_check:
+	IFS=$$'\n' sourceFiles=("$$(find src test -type f -name "*.hs")"); \
+	ormolu -m 'check' $${sourceFiles[*]}
 test-run:
 	stack test --pedantic --coverage
 	stack hpc report --all --destdir test/coverage
 
 test: test-run
 
-.PHONY: all clean fclean re quick test-run
+.PHONY: all clean fclean re quick test-run format format-check


### PR DESCRIPTION
we will now use the ormolu formatter to bring our code up to standard. make format brings all .hs files up to standard and format_check shows just where the coding style errors are and how to change them.